### PR TITLE
Rails 7 1 support(workaround for 7.1 DO NOT MERGE TO MASTER)

### DIFF
--- a/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
+++ b/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
@@ -39,7 +39,7 @@ module ActiveRecord
 
         @clear_connections =
           if ar_version >= "6.1"
-            if ActiveRecord::Base.legacy_connection_handling
+            if ActiveRecord.legacy_connection_handling
               :clear_legacy_compatible_connections
             else
               :clear_multi_db_connections

--- a/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
+++ b/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
@@ -53,9 +53,9 @@ module ActiveRecord
 
       def clear_multi_db_connections
         if should_clear_all_connections?
-          ActiveRecord::Base.connection_handler.all_connection_pools.each(&:disconnect!)
+          ActiveRecord::Base.connection_handler.connection_pool_list(:all).each(&:disconnect!)
         else
-          ActiveRecord::Base.connection_handler.all_connection_pools.each do |pool|
+          ActiveRecord::Base.connection_handler.connection_pool_list(:all).each do |pool|
             pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?
           end
         end

--- a/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
+++ b/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
@@ -39,7 +39,7 @@ module ActiveRecord
 
         @clear_connections =
           if ar_version >= "6.1"
-            if ActiveRecord.legacy_connection_handling
+            if false # ActiveRecord::Base.legacy_connection_handling
               :clear_legacy_compatible_connections
             else
               :clear_multi_db_connections

--- a/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
+++ b/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb
@@ -39,7 +39,7 @@ module ActiveRecord
 
         @clear_connections =
           if ar_version >= "6.1"
-            if false # ActiveRecord::Base.legacy_connection_handling
+            if (ActiveRecord::Base.method_defined? :legacy_connection_handling) ? ActiveRecord::Base.legacy_connection_handling : false
               :clear_legacy_compatible_connections
             else
               :clear_multi_db_connections


### PR DESCRIPTION
Fix the DEPRECATION WARNING: 
`The all_connection_pools method is deprecated in favor of connection_pool_list. Call connection_pool_list(:all) to get the same behavior as all_connection_pools. ("/home/runner/work/fril_web/fril_web/vendor/bundle/ruby/3.2.0/bundler/gems/activerecord-refresh_connection-a1cb377cb2fc/lib/activerecord-refresh_connection/active_record/connection_adapters/refresh_connection_management.rb:58)`